### PR TITLE
docs: add Terraform and OpenTofu registry links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,43 +9,90 @@ Thank you for your interest in contributing! This document outlines the developm
 - Go 1.23 or later
 - [Task](https://taskfile.dev) - Build automation tool
 - [golangci-lint](https://golangci-lint.run) - Linting tool
+- [oapi-codegen](https://github.com/deepmap/oapi-codegen) - OpenAPI code generator
+- [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs) - Documentation generator
 - Docker and Docker Compose - For running Uptrace locally
-- [gh](https://cli.github.com) - GitHub CLI (optional, for project management)
+- [gh](https://cli.github.com) - GitHub CLI (optional)
 
 ### Initial Setup
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/ricCap/terraform-provider-uptrace.git
-   cd terraform-provider-uptrace
-   ```
+```bash
+# Clone the repository
+git clone https://github.com/ricCap/terraform-provider-uptrace.git
+cd terraform-provider-uptrace
 
-2. Install dependencies:
-   ```bash
-   go mod download
-   ```
+# Install development dependencies
+task deps
 
-3. Generate API client code:
-   ```bash
-   task generate
-   ```
+# Generate API client code
+task generate
+
+# Build the provider
+task build
+```
+
+## Project Structure
+
+```
+.
+├── api/                    # OpenAPI specifications (source of truth)
+│   └── openapi.yaml       # Main API spec
+├── internal/
+│   ├── client/            # Uptrace API client
+│   │   ├── generated/     # Auto-generated client (never edit)
+│   │   ├── client.go      # Client wrapper with high-level methods
+│   │   └── client_test.go # Unit tests for client
+│   ├── provider/          # Terraform provider implementation
+│   │   ├── provider.go    # Provider configuration
+│   │   ├── *_resource.go  # Resource implementations (CRUD)
+│   │   ├── *_models.go    # Model conversion logic
+│   │   ├── *_data_source.go # Data source implementations
+│   │   └── *_acc_test.go  # Acceptance tests
+│   ├── acceptance_tests/  # Shared test utilities
+│   └── validators/        # Custom validators
+├── examples/              # Terraform examples for documentation
+├── docs/                  # Generated provider documentation
+├── dev-env/               # Docker Compose for local Uptrace
+└── tools/                 # Development tools
+```
+
+## Available Tasks
+
+Run `task --list` to see all available tasks:
+
+```
+* build:              Build the provider binary
+* deps:               Install development dependencies
+* generate:           Generate API client code from OpenAPI spec
+* docs:               Generate provider documentation
+* lint:               Run golangci-lint
+* lint:fix:           Run linters and auto-fix issues
+* test:unit:          Run unit tests
+* test:acc:           Run acceptance tests
+* test:coverage:unit: Run unit tests with coverage
+* test:coverage:acc:  Run acceptance tests with coverage
+* dev:up:             Start development environment (Uptrace + dependencies)
+* dev:down:           Stop development environment
+* dev:logs:           Show Uptrace logs
+```
 
 ## Development Workflow
 
 ### Running Tests
 
 ```bash
-# Run all tests
-task test
-
-# Run only unit tests
+# Run unit tests (no external dependencies)
 task test:unit
 
-# Run only acceptance tests (requires running Uptrace instance)
+# Start local Uptrace for acceptance tests
+task dev:up
+
+# Run acceptance tests
 task test:acc
 
-# Start local Uptrace for testing
-task dev:up
+# Run tests with coverage
+task test:coverage:unit
+task test:coverage:acc
 
 # Stop local Uptrace
 task dev:down
@@ -61,31 +108,46 @@ task lint
 task lint:fix
 ```
 
-### Building
-
-```bash
-# Build the provider
-task build
-
-# Install locally for testing
-task install
-```
-
 ### Code Generation
 
 ```bash
 # Generate API client from OpenAPI spec
-task generate:client
+task generate
 
 # Generate provider documentation
 task docs
 ```
 
+**Important**: Always run `task generate` after modifying `api/openapi.yaml`. The generated client is the source of truth for API types.
+
+## Testing Against Local Uptrace
+
+The acceptance tests require a running Uptrace instance:
+
+```bash
+# Start Uptrace with Docker Compose
+task dev:up
+
+# Run acceptance tests
+task test:acc
+
+# View Uptrace logs
+task dev:logs
+
+# Stop Uptrace
+task dev:down
+```
+
+**Local Uptrace credentials:**
+- Endpoint: `http://localhost:14318/internal/v1`
+- Token: `user1_secret_token`
+- Project ID: `1`
+
 ## Pull Request Process
 
 1. **Create a feature branch**:
    ```bash
-   git checkout -b feature/your-feature-name
+   git checkout -b feat/your-feature-name
    ```
 
 2. **Make your changes** and commit frequently:
@@ -96,20 +158,21 @@ task docs
 
 3. **Run tests and linting locally**:
    ```bash
-   task test
+   task test:unit
    task lint
    ```
 
 4. **Push your branch**:
    ```bash
-   git push origin feature/your-feature-name
+   git push -u origin feat/your-feature-name
    ```
 
-5. **Create a Pull Request** on GitHub
+5. **Create a Pull Request** on GitHub:
+   ```bash
+   gh pr create --title "feat: your feature" --body "Description"
+   ```
 
 6. **Wait for CI to pass** - All tests and linting must pass before merge
-
-7. **Request review** - Tag the maintainer for review
 
 ## Commit Message Convention
 
@@ -131,62 +194,41 @@ docs: update installation instructions
 test: add unit tests for monitor models
 ```
 
-## GitHub Workflows Setup
-
-### Documentation Workflow
-
-The documentation workflow (`docs.yml`) auto-generates provider documentation.
-
-**Required Setup**:
-1. Go to **Settings → Actions → General**
-2. Scroll to **Workflow permissions**
-3. ✓ Check **"Allow GitHub Actions to create and approve pull requests"**
-
-Without this, the workflow will fail with:
-```
-GitHub Actions is not permitted to create or approve pull requests
-```
-
-### Auto-assign to Project Workflow
-
-The auto-assign workflow adds new issues/PRs to the GitHub Project board.
-
-**Note**: This workflow currently doesn't work for user-level projects because `GITHUB_TOKEN` lacks project permissions.
-
-**Options**:
-1. **Manual assignment**: Use `gh project item-add` to manually add items
-2. **Use PAT** (if you want automation):
-   - Create a Personal Access Token with `project` and `repo` scopes
-   - Add it as repository secret `PROJECT_TOKEN`
-   - Update workflow to use `${{ secrets.PROJECT_TOKEN }}`
-
-## Testing Against Local Uptrace
-
-The acceptance tests require a running Uptrace instance:
-
-```bash
-# Start Uptrace with Docker Compose
-task dev:up
-
-# Run acceptance tests
-task test:acc
-
-# View Uptrace logs
-task dev:logs
-
-# Stop Uptrace
-task dev:down
-```
-
-Default Uptrace endpoint: `http://localhost:14318`
-
 ## Code Style
 
 - Follow standard Go conventions
 - Run `gofmt` and `goimports` (handled by linter)
+- All comments must end with a period (godot linter)
 - Document exported functions and types
 - Add tests for new functionality
 - Keep cyclomatic complexity under 15
+
+### Linting Notes
+
+The golangci-lint config is strict. Common issues:
+
+1. **godot**: All comments must end with a period
+2. **revive unused-parameter**: Rename unused params to `_`
+3. **gocritic paramTypeCombine**: Combine consecutive same-type params: `func(a, b string)`
+4. **dupl**: Use `//nolint:dupl` with justification for acceptable duplicates
+
+## Adding New Features
+
+### Adding API Endpoints
+
+1. Update OpenAPI spec in `api/openapi.yaml`
+2. Run `task generate` to regenerate client
+3. Add wrapper methods in `internal/client/client.go`
+4. Add unit tests in `internal/client/client_test.go`
+5. Create/update provider resources in `internal/provider/`
+
+### Adding Provider Resources
+
+1. Create `*_resource.go` with CRUD operations
+2. Create `*_models.go` for model conversion
+3. Add acceptance tests in `*_acc_test.go`
+4. Add examples in `examples/resources/`
+5. Run `task docs` to generate documentation
 
 ## Questions or Issues?
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 A Terraform provider for managing [Uptrace](https://uptrace.dev/) monitoring resources - monitors, dashboards, and notification channels.
 
+[![Terraform Registry](https://img.shields.io/badge/Terraform-Registry-purple?logo=terraform)](https://registry.terraform.io/providers/riccap/uptrace)
 [![OpenTofu Registry](https://img.shields.io/badge/OpenTofu-Registry-blue?logo=opentofu)](https://search.opentofu.org/provider/riccap/uptrace)
 [![Tests](https://github.com/riccap/terraform-provider-uptrace/actions/workflows/test.yml/badge.svg)](https://github.com/riccap/terraform-provider-uptrace/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/riccap/terraform-provider-uptrace/branch/main/graph/badge.svg)](https://codecov.io/gh/riccap/terraform-provider-uptrace)
 [![Go Report Card](https://goreportcard.com/badge/github.com/riccap/terraform-provider-uptrace)](https://goreportcard.com/report/github.com/riccap/terraform-provider-uptrace)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> This provider is in early development. Any feedback is welcome (just create an issue)! Many of the features still need thorough manual testing.
+> This provider is in early development. Any feedback is welcome (just create an issue)!
 
 ## Features
 
@@ -16,61 +17,10 @@ A Terraform provider for managing [Uptrace](https://uptrace.dev/) monitoring res
 - **Dashboard Creation**: YAML-based dashboards with flexible grid layouts and visualizations
 - **Notification Channels**: Support for Slack, Telegram, Mattermost, and generic webhooks
 - **Data Sources**: Query individual monitors or filter multiple monitors by criteria
-- **Type-Safe Client**: Auto-generated client from OpenAPI specifications
 - **Full CRUD Support**: Complete lifecycle management for all resources
 - **Import Support**: Import existing Uptrace resources into Terraform state
 
-## Cloud API Support
-
-The provider supports both:
-- **Uptrace Cloud** (`api2.uptrace.dev`) - Managed Uptrace service
-- **Self-Hosted Uptrace** - Your own Uptrace instance
-
-Some fields are required only for cloud API. See the [Cloud API Guide](docs/guides/cloud-api.md) for details.
-
-### Feature Compatibility
-
-| Feature | Self-Hosted | Uptrace Cloud | Notes |
-|---------|-------------|---------------|-------|
-| **Monitor Resource** | ✅ Full Support | ✅ Full Support | Cloud normalizes queries to canonical UQL form, which may cause displayed values to differ from input. Use `lifecycle { ignore_changes = [params] }` if needed. |
-| **Dashboard Resource** | ✅ Full Support | ✅ Full Support | YAML-based dashboards work identically across both platforms. |
-| **Notification Channels** | ✅ Full Support | ✅ Full Support | All channel types (Slack, Telegram, Mattermost, Webhook) supported. |
-| **Data Sources** | ✅ Full Support | ✅ Full Support | Query individual monitors or filter by criteria. |
-| **Monitor `trend_agg_func`** | ⚠️ Optional | ✅ Required | Required for cloud API. Optional for self-hosted v2.0.2 and earlier. Valid values: `avg`, `sum`, `min`, `max`, `p50`, `p90`, `p95`, `p99`. |
-| **Channel `priority` field** | ➖ Not Applicable | ❌ Not Functional | Cloud UI shows priority options (Info, Low, Medium, High) but API currently rejects all values. Feature appears to be UI-only. Provider correctly implements the field for when API support is added. |
-| **Import Support** | ✅ Full Support | ✅ Full Support | Import existing resources into Terraform state. |
-
-**Legend:**
-- ✅ **Full Support** - Feature works as expected
-- ⚠️ **Optional** - Feature available but not required
-- ❌ **Not Functional** - Feature not yet working (API limitation)
-- ➖ **Not Applicable** - Feature not available for this platform
-
-See [CHANGELOG.md](CHANGELOG.md) for version history and [Cloud API Guide](docs/guides/cloud-api.md) for cloud-specific configuration details.
-
-## Requirements
-
-- [Terraform](https://www.terraform.io/downloads.html) or [OpenTofu](https://opentofu.org/) >= 1.0
-- [Uptrace](https://uptrace.dev/) instance with API access
-- Uptrace API token and project ID
-
-## Building The Provider
-
-```bash
-go build -o terraform-provider-uptrace
-```
-
-Or using Task:
-
-```bash
-task build
-```
-
-## Quick Start
-
-### Installation
-
-**OpenTofu** (recommended):
+## Installation
 
 ```hcl
 terraform {
@@ -89,329 +39,60 @@ provider "uptrace" {
 }
 ```
 
-**Terraform** (pending registry approval - use GitHub releases):
+The provider can also be configured via environment variables:
 
-```hcl
-terraform {
-  required_providers {
-    uptrace = {
-      source  = "github.com/riccap/terraform-provider-uptrace"
-      version = "~> 0.3"
-    }
-  }
-}
+```bash
+export UPTRACE_ENDPOINT="https://uptrace.example.com/api/v1"
+export UPTRACE_TOKEN="your-api-token"
+export UPTRACE_PROJECT_ID="1"
 ```
 
-See [OpenTofu Registry](https://search.opentofu.org/provider/riccap/uptrace) for full documentation.
-
-### Configuration
-
-The provider can be configured via:
-
-1. **HCL variables** (shown above)
-2. **Environment variables**:
-   ```bash
-   export UPTRACE_ENDPOINT="https://uptrace.example.com/api/v1"
-   export UPTRACE_TOKEN="your-api-token"
-   export UPTRACE_PROJECT_ID="1"
-   ```
-
-### Example Usage
-
-**Create a Notification Channel:**
+## Example Usage
 
 ```hcl
-resource "uptrace_notification_channel" "slack_alerts" {
+# Create a notification channel
+resource "uptrace_notification_channel" "slack" {
   name = "Engineering Alerts"
   type = "slack"
-
-  params = {
-    webhookUrl = var.slack_webhook_url
-  }
+  params = { webhookUrl = var.slack_webhook_url }
 }
-```
 
-**Create an Error Monitor:**
-
-```hcl
+# Create an error monitor
 resource "uptrace_monitor" "api_errors" {
-  name = "High Error Rate"
-  type = "error"
-
-  channel_ids = [uptrace_notification_channel.slack_alerts.id]
+  name        = "High Error Rate"
+  type        = "error"
+  channel_ids = [uptrace_notification_channel.slack.id]
 
   params = {
-    metrics = [
-      {
-        name = "span.count"
-      }
-    ]
-    query = "service.name:api-gateway span.status_code:error"
-
+    metrics           = [{ name = "span.count" }]
+    query             = "service.name:api-gateway span.status_code:error"
     max_allowed_value = 100
     check_num_point   = 1
   }
 }
 ```
 
-**Create a Performance Monitor:**
-
-```hcl
-resource "uptrace_monitor" "api_latency" {
-  name = "API Response Time >2s"
-  type = "metric"
-
-  channel_ids = [uptrace_notification_channel.slack_alerts.id]
-
-  params = {
-    metrics = [
-      {
-        name  = "span.duration"
-        alias = "$p95_latency"
-      }
-    ]
-
-    query = "span.system:http span.kind:server"
-
-    max_allowed_value = 2000000000  # 2 seconds in nanoseconds
-    column            = "$p95_latency"
-    check_num_point   = 2
-  }
-}
-```
-
-**Create a Dashboard:**
-
-```hcl
-resource "uptrace_dashboard" "api_overview" {
-  yaml = <<-YAML
-    schema: v2
-    name: API Overview
-    grid_rows:
-      - title: Performance
-        items:
-          - title: Request Rate
-            metrics:
-              - span.count as $requests
-            query:
-              - per_min(sum($requests))
-            where:
-              - span.system
-              - =
-              - http
-          - title: P95 Latency
-            metrics:
-              - span.duration as $duration
-            query:
-              - p95($duration)
-            where:
-              - span.system
-              - =
-              - http
-      - title: Errors
-        items:
-          - title: Error Rate
-            metrics:
-              - span.count as $errors
-            query:
-              - per_min(sum($errors))
-            where:
-              - span.status_code
-              - =
-              - error
-  YAML
-}
-```
-
 ## Documentation
 
-- **[OpenTofu Registry Docs](https://search.opentofu.org/provider/riccap/uptrace)** - Official provider documentation
-- **[Getting Started Guide](docs/guides/getting-started.md)** - Complete introduction with examples
-- **[Best Practices Guide](docs/guides/best-practices.md)** - Production recommendations
+- **[Terraform Registry Docs](https://registry.terraform.io/providers/riccap/uptrace/latest/docs)** - Full provider documentation
+- **[OpenTofu Registry Docs](https://search.opentofu.org/provider/riccap/uptrace)** - OpenTofu documentation
+- **[Getting Started Guide](docs/guides/getting-started.md)** - Complete introduction
 - **[Cloud API Guide](docs/guides/cloud-api.md)** - Uptrace Cloud configuration
-- **[Resource Documentation](docs/)** - Detailed resource and data source reference
 - **[Example Configurations](examples/)** - Real-world usage examples
 
-## Examples
+## Cloud API Support
 
-### Complete Examples
-
-- **[Dashboard Examples](examples/dashboard-examples/)** - 8 dashboard patterns (RED metrics, database performance, business metrics, etc.)
-- **[Multi-Channel Alerts](examples/multi-channel-alerts/)** - Advanced notification routing patterns
-- **[Complete Setup](examples/complete-setup/)** - Full monitoring stack with channels, monitors, and dashboards
-
-### Resource Examples
-
-- **[Monitor Resource](examples/resources/uptrace_monitor/)** - Metric and error monitor configurations
-- **[Dashboard Resource](examples/resources/uptrace_dashboard/)** - Dashboard YAML examples
-- **[Notification Channel Resource](examples/resources/uptrace_notification_channel/)** - Channel configurations for all supported types
-
-## Development
-
-### Prerequisites
-
-- Go 1.21+
-- [Task](https://taskfile.dev/) - Task runner for development commands
-- [golangci-lint](https://golangci-lint.run/) - Go linter
-- [oapi-codegen](https://github.com/deepmap/oapi-codegen) - OpenAPI code generator
-- [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs) - Documentation generator
-- [Docker](https://www.docker.com/) - For running local Uptrace instance and acceptance tests
-
-### Setup
-
-```bash
-# Install development dependencies
-task deps
-
-# Generate API client from OpenAPI spec
-task generate
-
-# Build the provider
-task build
-
-# Run unit tests
-task test:unit
-
-# Run linters
-task lint
-
-# Start local Uptrace instance for testing
-task dev:up
-
-# Run acceptance tests (requires running Uptrace instance)
-task test:acc
-
-# Stop local Uptrace instance
-task dev:down
-
-# Generate documentation
-task docs
-```
-
-### Available Tasks
-
-Run `task --list` to see all available tasks:
-
-```
-* build:          Build the provider binary
-* deps:           Install development dependencies
-* dev:down:       Stop development environment
-* dev:up:         Start development environment (Uptrace + dependencies)
-* docs:           Generate provider documentation
-* generate:       Generate API client code from OpenAPI spec
-* lint:           Run golangci-lint
-* test:acc:       Run acceptance tests
-* test:unit:      Run unit tests
-* test:           Run all tests
-```
-
-### Project Structure
-
-```
-.
-├── api/                    # OpenAPI specifications
-├── internal/
-│   ├── client/            # Uptrace API client
-│   ├── provider/          # Terraform provider implementation
-│   └── validators/        # Custom validators
-├── examples/              # Example configurations
-├── docs/                  # Generated documentation
-└── tools/                 # Development tools
-```
-
-## Testing
-
-### Unit Tests
-
-Run unit tests without requiring an Uptrace instance:
-
-```bash
-task test:unit
-```
-
-### Acceptance Tests
-
-Acceptance tests create real resources in an Uptrace instance.
-
-**Option 1: Use local Uptrace instance (recommended for development):**
-
-```bash
-# Start local Uptrace with Docker Compose
-task dev:up
-
-# Run acceptance tests
-task test:acc
-
-# Stop local instance when done
-task dev:down
-```
-
-**Option 2: Use existing Uptrace instance:**
-
-```bash
-export UPTRACE_ENDPOINT="https://uptrace.example.com/api/v1"
-export UPTRACE_TOKEN="your-api-token"
-export UPTRACE_PROJECT_ID="1"
-
-task test:acc
-```
-
-### Linting
-
-```bash
-task lint
-```
+The provider supports both **Uptrace Cloud** (`api2.uptrace.dev`) and **Self-Hosted Uptrace**. See the [Cloud API Guide](docs/guides/cloud-api.md) for details on cloud-specific fields like `trend_agg_func`.
 
 ## Contributing
 
-Contributions are welcome! Here's how to get started:
-
-1. **Fork the repository**
-2. **Create a feature branch**: `git checkout -b feature/my-feature`
-3. **Make your changes**
-4. **Run tests**: `task test`
-5. **Run linters**: `task lint`
-6. **Commit your changes**: `git commit -m 'feat: add my feature'`
-7. **Push to your fork**: `git push origin feature/my-feature`
-8. **Open a Pull Request**
-
-### Development Guidelines
-
-- Follow existing code style and patterns
-- Add tests for new features
-- Update documentation as needed
-- Keep commits focused and atomic
-- Write clear commit messages
-
-### Generating Documentation
-
-Documentation is auto-generated from code and examples:
-
-```bash
-task docs
-```
-
-This generates resource documentation from:
-- Schema definitions in `internal/provider/`
-- Examples in `examples/resources/` and `examples/data-sources/`
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## Support
 
 - **[GitHub Issues](https://github.com/riccap/terraform-provider-uptrace/issues)** - Bug reports and feature requests
-- **[GitHub Discussions](https://github.com/riccap/terraform-provider-uptrace/discussions)** - Questions and community support
 - **[Uptrace Documentation](https://uptrace.dev/docs/)** - Uptrace platform documentation
-- **[Getting Started Guide](docs/guides/getting-started.md)** - Provider usage guide
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
 
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.
-
-## Acknowledgments
-
-- Built with [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework)
-- API client generated with [oapi-codegen](https://github.com/deepmap/oapi-codegen)
-- Designed for [Uptrace](https://uptrace.dev/) observability platform

--- a/docs/guides/cloud-api.md
+++ b/docs/guides/cloud-api.md
@@ -4,6 +4,24 @@
 
 The provider supports both self-hosted Uptrace instances and the Uptrace cloud API at `api2.uptrace.dev`.
 
+## Feature Compatibility
+
+| Feature | Self-Hosted | Uptrace Cloud | Notes |
+|---------|-------------|---------------|-------|
+| **Monitor Resource** | ✅ Full Support | ✅ Full Support | Cloud normalizes queries to canonical UQL form. Use `lifecycle { ignore_changes = [params] }` if needed. |
+| **Dashboard Resource** | ✅ Full Support | ✅ Full Support | YAML-based dashboards work identically across both platforms. |
+| **Notification Channels** | ✅ Full Support | ✅ Full Support | All channel types (Slack, Telegram, Mattermost, Webhook) supported. |
+| **Data Sources** | ✅ Full Support | ✅ Full Support | Query individual monitors or filter by criteria. |
+| **Monitor `trend_agg_func`** | ⚠️ Optional | ✅ Required | Required for cloud API. Optional for self-hosted v2.0.2 and earlier. |
+| **Channel `priority` field** | ➖ Not Applicable | ❌ Not Functional | Cloud UI shows priority options but API currently rejects all values. |
+| **Import Support** | ✅ Full Support | ✅ Full Support | Import existing resources into Terraform state. |
+
+**Legend:**
+- ✅ **Full Support** - Feature works as expected
+- ⚠️ **Optional** - Feature available but not required
+- ❌ **Not Functional** - Feature not yet working (API limitation)
+- ➖ **Not Applicable** - Feature not available for this platform
+
 ## Cloud-Specific Fields
 
 ### Notification Channels


### PR DESCRIPTION
## Summary
- Streamline README (409 → 99 lines) for better user experience
- Move development content to CONTRIBUTING.md
- Add both Terraform and OpenTofu registry links
- Move Feature Compatibility matrix to Cloud API guide

## README Changes
- Add Terraform Registry badge
- Simplify installation to single example
- Condense example usage
- Remove development, testing, and detailed contributing sections
- Add link to CONTRIBUTING.md

## CONTRIBUTING.md Changes
- Add project structure diagram
- Add complete list of available tasks
- Add local Uptrace credentials
- Add sections for adding new features (API endpoints, provider resources)
- Add linting notes

## Cloud API Guide Changes
- Add Feature Compatibility matrix (moved from README)
- Documents Self-Hosted vs Cloud differences

## Registry Links
- Terraform: https://registry.terraform.io/providers/riccap/uptrace
- OpenTofu: https://search.opentofu.org/provider/riccap/uptrace

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)